### PR TITLE
use binary-search-bounds v2 in planar-graph-to-polyline

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/mikolalysenko/planar-graph-to-polyline",
   "dependencies": {
     "edges-to-adjacency-list": "^1.0.0",
-    "point-in-big-polygon": "^2.0.0",
+    "point-in-big-polygon": "^2.0.1",
     "robust-orientation": "^1.0.1",
     "planar-dual": "^1.0.0",
     "two-product": "^1.0.0",


### PR DESCRIPTION
`point-in-big-polygon@2.0.1` uses `binary-search-bounds` v2 which has no function constructor.
Follow up of https://github.com/mikolalysenko/point-in-big-polygon/pull/5.
@mikolalysenko 

cc: @alexcjohnson
cc: plotly/plotly.js#897
cc: https://github.com/mikolalysenko/binary-search-bounds/pull/8
